### PR TITLE
fix: feature multipart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.swp
 .idea
+.zed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ charset = ["dep:encoding_rs"]
 
 json = ["dep:serde_json"]
 
-multipart = ["dep:mime_guess"]
+multipart = ["dep:mime_guess", "dep:rand"]
 
 [dependencies]
 base64 = "0.22"
@@ -51,6 +51,7 @@ sync_wrapper = { version = "1.0", features = ["futures"] }
 serde_json = { version = "1.0", optional = true }
 ## multipart
 mime_guess = { version = "2.0", default-features = false, optional = true }
+rand = { version = "0.9.1", optional = true }
 
 wit-bindgen-rt = { version = "0.41.0", features = ["bitflags"] }
 encoding_rs = { version = "0.8", optional = true }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -8604,9 +8604,7 @@ mod _rt {
     extern crate alloc as alloc_crate;
 }
 #[cfg(target_arch = "wasm32")]
-#[unsafe(
-    link_section = "component-type:wit-bindgen:0.41.0:reqwest:wasi:http-client:encoded world"
-)]
+#[unsafe(link_section = "component-type:wit-bindgen:0.41.0:reqwest:wasi:http-client:encoded world")]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
 pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 6448] = *b"\

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -152,6 +152,14 @@ impl Body {
             .map(|kind| Body { kind: Some(kind) })
     }
 
+    pub(crate) fn len(&self) -> Option<u64> {
+        match self.kind.as_ref()? {
+            Kind::Reader(_, len) => *len,
+            Kind::Bytes(bytes) => Some(bytes.len() as u64),
+            Kind::Incoming(_) => None,
+        }
+    }
+
     pub(crate) fn write(
         mut self,
         mut f: impl FnMut(&[u8]) -> Result<(), crate::Error>,

--- a/src/wasi/multipart.rs
+++ b/src/wasi/multipart.rs
@@ -439,7 +439,7 @@ impl<P: PartProps> FormParts<P> {
     // but not if a generic reader has been added;
     pub(crate) fn compute_length(&mut self) -> Option<u64> {
         let mut length = 0u64;
-        for &(ref name, ref field) in self.fields.iter() {
+        for (name, field) in self.fields.iter() {
             match field.value_len() {
                 Some(value_length) => {
                     // We are constructing the header just to get its length. To not have to
@@ -467,11 +467,6 @@ impl<P: PartProps> FormParts<P> {
             length += 2 + self.boundary().len() as u64 + 4
         }
         Some(length)
-    }
-
-    /// Take the fields vector of this instance, replacing with an empty vector.
-    fn take_fields(&mut self) -> Vec<(Cow<'static, str>, P)> {
-        std::mem::replace(&mut self.fields, Vec::new())
     }
 }
 
@@ -623,11 +618,11 @@ impl PercentEncoding {
 fn gen_boundary() -> String {
     use rand::prelude::*;
 
-    let mut rng = rand::thread_rng();
-    let a = rng.gen::<u64>();
-    let b = rng.gen::<u64>();
-    let c = rng.gen::<u64>();
-    let d = rng.gen::<u64>();
+    let mut rng = rand::rng();
+    let a = rng.random::<u64>();
+    let b = rng.random::<u64>();
+    let c = rng.random::<u64>();
+    let d = rng.random::<u64>();
 
     format!("{:016x}-{:016x}-{:016x}-{:016x}", a, b, c, d)
 }
@@ -738,5 +733,31 @@ mod tests {
         );
         println!("START EXPECTED\n{}\nEND EXPECTED", expected);
         assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_boundary_generation() {
+        let boundary1 = gen_boundary();
+        let boundary2 = gen_boundary();
+
+        assert_ne!(boundary1, boundary2);
+
+        assert!(!boundary1.is_empty());
+        assert!(!boundary2.is_empty());
+
+        for c in boundary1.chars() {
+            assert!(c.is_ascii_hexdigit() || c == '-');
+        }
+        for c in boundary2.chars() {
+            assert!(c.is_ascii_hexdigit() || c == '-');
+        }
+
+        // Should follow the expected format (16 hex chars, dash, repeat 4 times)
+        let parts: Vec<&str> = boundary1.split('-').collect();
+        assert_eq!(parts.len(), 4);
+        for part in parts {
+            assert_eq!(part.len(), 16);
+            assert!(part.chars().all(|c| c.is_ascii_hexdigit()));
+        }
     }
 }


### PR DESCRIPTION
This PR should fix following issues when enabling `multipart` feature.

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rand`
   --> /Users/.../.cargo/git/checkouts/reqwest-9077096f08e888ce/c916d79/src/wasi/multipart.rs:626:19
    |
626 |     let mut rng = rand::thread_rng();
    |                   ^^^^ use of unresolved module or unlinked crate `rand`
    |
    = help: if you wanted to use a crate named `rand`, use `cargo add rand` to add it to your `Cargo.toml`
```

```
error[E0599]: no method named `len` found for struct `Body` in the current scope
   --> /Users/kmatas/.cargo/git/checkouts/reqwest-9077096f08e888ce/c916d79/src/wasi/multipart.rs:305:20
    |
305 |         self.value.len()
    |                    ^^^ method not found in `Body`
    |
   ::: /Users/kmatas/.cargo/git/checkouts/reqwest-9077096f08e888ce/c916d79/src/wasi/body.rs:10:1
    |
10  | pub struct Body {
    | --------------- method `len` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `len`, perhaps you need to implement it:
            candidate #1: `ExactSizeIterator`
```

verified by running:
```
RUSTFLAGS="-A unused" cargo test --features multipart --lib multipart::tests
```