### PR TITLE
Fix write exceeded budget

### DIFF
--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 2];
+                let mut buf = [0; 4 * 1024];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 2).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 4 * 1024).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 2 * 1024];
+                let mut buf = [0; 64];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 2 * 1024).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 64).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -372,12 +372,11 @@ mod tests {
     }
 
     #[test]
-    fn test_chunk_iter_last_small_chunk() {
+    fn test_chunk_iter_only_one_chunk() {
         let data = b"hello world".to_vec();
-        let mut chunk_iter = ChunkIter::new(&data, 7);
+        let mut chunk_iter = ChunkIter::new(&data, 11);
 
-        assert_eq!(chunk_iter.next(), Some(&b"hello w"[..]));
-        assert_eq!(chunk_iter.next(), Some(&b"orld"[..]));
+        assert_eq!(chunk_iter.next(), Some(&b"hello world"[..]));
         assert_eq!(chunk_iter.next(), None);
     }
 

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -11,18 +11,18 @@ pub struct Body {
     kind: Option<Kind>,
 }
 
-struct ChunkIter<'a> {
+struct ChunkIterator<'a> {
     bytes: &'a [u8],
     chunk_size: usize,
 }
 
-impl<'a> ChunkIter<'a> {
+impl<'a> ChunkIterator<'a> {
     fn new(bytes: &'a [u8], chunk_size: usize) -> Self {
-        ChunkIter { bytes, chunk_size }
+        ChunkIterator { bytes, chunk_size }
     }
 }
 
-impl<'a> Iterator for ChunkIter<'a> {
+impl<'a> Iterator for ChunkIterator<'a> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 4 * 1024).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIterator::new(&bytes, 4 * 1024).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {
@@ -361,9 +361,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_chunk_iter_regular_slices() {
+    fn test_chunk_iterator_regular_slices() {
         let data = b"hello world".to_vec();
-        let mut chunk_iter = ChunkIter::new(&data, 5);
+        let mut chunk_iter = ChunkIterator::new(&data, 5);
 
         assert_eq!(chunk_iter.next(), Some(&b"hello"[..]));
         assert_eq!(chunk_iter.next(), Some(&b" worl"[..]));
@@ -372,27 +372,27 @@ mod tests {
     }
 
     #[test]
-    fn test_chunk_iter_only_one_chunk() {
+    fn test_chunk_iterator_only_one_chunk() {
         let data = b"hello world".to_vec();
-        let mut chunk_iter = ChunkIter::new(&data, 11);
+        let mut chunk_iter = ChunkIterator::new(&data, 11);
 
         assert_eq!(chunk_iter.next(), Some(&b"hello world"[..]));
         assert_eq!(chunk_iter.next(), None);
     }
 
     #[test]
-    fn test_chunk_iter_single_byte() {
+    fn test_chunk_iterator_single_byte() {
         let data = b"x".to_vec();
-        let mut chunk_iter = ChunkIter::new(&data, 2);
+        let mut chunk_iter = ChunkIterator::new(&data, 2);
 
         assert_eq!(chunk_iter.next(), Some(&b"x"[..]));
         assert_eq!(chunk_iter.next(), None);
     }
 
     #[test]
-    fn test_chunk_iter_empty_slice() {
+    fn test_chunk_iterator_empty_slice() {
         let data: Vec<u8> = vec![];
-        let mut chunk_iter = ChunkIter::new(&data, 5);
+        let mut chunk_iter = ChunkIterator::new(&data, 5);
 
         assert_eq!(chunk_iter.next(), None);
     }

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 4 * 1024];
+                let mut buf = [0; 2 * 1024];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 4 * 1024).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 2 * 1024).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 3726];
+                let mut buf = [0; 4 * 1024];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 3726).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 4 * 1024).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 8 * 1024];
+                let mut buf = [0; 4 * 1024];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 8 * 1024).try_for_each(|chunk| f(chunk)),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 4 * 1024).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -11,6 +11,33 @@ pub struct Body {
     kind: Option<Kind>,
 }
 
+struct ChunkIter<'a> {
+    bytes: &'a [u8],
+    chunk_size: usize,
+}
+
+impl<'a> ChunkIter<'a> {
+    fn new(bytes: &'a [u8], chunk_size: usize) -> Self {
+        ChunkIter { bytes, chunk_size }
+    }
+}
+
+impl<'a> Iterator for ChunkIter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bytes.is_empty() {
+            return None;
+        }
+
+        let chunk_size = std::cmp::min(self.chunk_size, self.bytes.len());
+        let (chunk, rest) = self.bytes.split_at(chunk_size);
+        self.bytes = rest;
+
+        Some(chunk)
+    }
+}
+
 impl Body {
     /// Instantiate a `Body` from a reader.
     ///
@@ -168,7 +195,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => f(&bytes),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 8 * 1024).try_for_each(|chunk| f(chunk)),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {
@@ -318,5 +345,47 @@ impl Read for Reader {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chunk_iter_regular_slices() {
+        let data = b"hello world".to_vec();
+        let mut chunk_iter = ChunkIter::new(&data, 5);
+
+        assert_eq!(chunk_iter.next(), Some(&b"hello"[..]));
+        assert_eq!(chunk_iter.next(), Some(&b" world"[..]));
+        assert_eq!(chunk_iter.next(), None);
+    }
+
+    #[test]
+    fn test_chunk_iter_last_small_chunk() {
+        let data = b"hello world".to_vec();
+        let mut chunk_iter = ChunkIter::new(&data, 7);
+
+        assert_eq!(chunk_iter.next(), Some(&b"hello wo"[..]));
+        assert_eq!(chunk_iter.next(), Some(&b"rld"[..]));
+        assert_eq!(chunk_iter.next(), None);
+    }
+
+    #[test]
+    fn test_chunk_iter_single_byte() {
+        let data = b"x".to_vec();
+        let mut chunk_iter = ChunkIter::new(&data, 2);
+
+        assert_eq!(chunk_iter.next(), Some(&b"x"[..]));
+        assert_eq!(chunk_iter.next(), None);
+    }
+
+    #[test]
+    fn test_chunk_iter_empty_slice() {
+        let data: Vec<u8> = vec![];
+        let mut chunk_iter = ChunkIter::new(&data, 5);
+
+        assert_eq!(chunk_iter.next(), None);
     }
 }

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 64];
+                let mut buf = [0; 2];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 64).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 2).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/body.rs
+++ b/src/wasi/body.rs
@@ -193,7 +193,7 @@ impl Body {
     ) -> Result<(), crate::Error> {
         match self.kind.take().expect("Body has already been extracted") {
             Kind::Reader(mut reader, _) => {
-                let mut buf = [0; 4 * 1024];
+                let mut buf = [0; 3726];
                 loop {
                     let len = reader.read(&mut buf).map_err(crate::error::builder)?;
                     if len == 0 {
@@ -203,7 +203,7 @@ impl Body {
                 }
                 Ok(())
             }
-            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 4 * 1024).try_for_each(&mut f),
+            Kind::Bytes(bytes) => ChunkIter::new(&bytes, 3726).try_for_each(&mut f),
             Kind::Incoming(ref body_stream) => {
                 let mut eof = false;
                 while !eof {

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -219,12 +219,14 @@ impl Client {
                 let mut remaining = chunk;
                 while !remaining.is_empty() {
                     let n = request_body_stream.check_write()?;
-                    println!("Writing {} bytes", n);
+                    println!("Write capacity {} bytes", n);
 
-                    let write_size = std::cmp::min(n, remaining.len() as u64);
-                    let (to_write, rest) = remaining.split_at(write_size as usize);
-                    request_body_stream.write(to_write)?;
-                    remaining = rest;
+                    if n != 0 {
+                        let write_size = std::cmp::min(n, remaining.len() as u64);
+                        let (to_write, rest) = remaining.split_at(write_size as usize);
+                        request_body_stream.write(to_write)?;
+                        remaining = rest;
+                    }
                 }
 
                 Ok(())

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -216,7 +216,17 @@ impl Client {
                 .write()
                 .map_err(|e| failure_point("write", e))?;
             body.write(|chunk| {
-                request_body_stream.blocking_write_and_flush(chunk)?;
+                let mut remaining = chunk;
+                while !remaining.is_empty() {
+                    let n = request_body_stream.check_write()?;
+                    println!("Writing {} bytes", n);
+
+                    let write_size = std::cmp::min(n, remaining.len() as u64);
+                    let (to_write, rest) = remaining.split_at(write_size as usize);
+                    request_body_stream.write(to_write)?;
+                    remaining = rest;
+                }
+
                 Ok(())
             })?;
             drop(request_body_stream);

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -237,14 +237,14 @@ impl Client {
         let future_incoming_response = outgoing_handler::handle(request, Some(options))?;
 
         if let Some((body, outgoing_body)) = maybe_outgoing_body {
-            let request_body_stream = outgoing_body
+            let outgoing_body_stream = outgoing_body
                 .write()
                 .map_err(|e| failure_point("write", e))?;
             body.write(|chunk| {
-                request_body_stream.blocking_write_and_flush(chunk)?;
+                outgoing_body_stream.blocking_write_and_flush(chunk)?;
                 Ok(())
             })?;
-            drop(request_body_stream);
+            drop(outgoing_body_stream);
             types::OutgoingBody::finish(outgoing_body, None)?;
         }
 

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -210,32 +210,20 @@ impl Client {
             .set_authority(Some(url.authority()))
             .map_err(|e| failure_point("set_authority", e))?;
 
-        if let Some(body) = body {
+        if let Some(mut body) = body {
+            let body_bytes = body.buffer()?;
+            println!("Total body size: {} bytes", body_bytes.len());
+
             let request_body = request.body().map_err(|e| failure_point("body", e))?;
             let request_body_stream = request_body
                 .write()
                 .map_err(|e| failure_point("write", e))?;
-            body.write(|chunk| {
-                let mut remaining = chunk;
-                while !remaining.is_empty() {
-                    let n = request_body_stream.check_write()?;
-                    println!("Write capacity {} bytes", n);
 
-                    if n == 0 {
-                        println!("Stream has no capacity - wait for it to become writable");
-                        let pollable = request_body_stream.subscribe();
-                        pollable.block(); // Wait until stream is ready
-                        continue;
-                    }
+            // write the whole body in one go
+            if !body_bytes.is_empty() {
+                request_body_stream.write(body_bytes)?;
+            }
 
-                    let write_size = std::cmp::min(n, remaining.len() as u64);
-                    let (to_write, rest) = remaining.split_at(write_size as usize);
-                    request_body_stream.write(to_write)?;
-                    remaining = rest;
-                }
-
-                Ok(())
-            })?;
             drop(request_body_stream);
             types::OutgoingBody::finish(request_body, None)?;
         }

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -221,12 +221,17 @@ impl Client {
                     let n = request_body_stream.check_write()?;
                     println!("Write capacity {} bytes", n);
 
-                    if n != 0 {
-                        let write_size = std::cmp::min(n, remaining.len() as u64);
-                        let (to_write, rest) = remaining.split_at(write_size as usize);
-                        request_body_stream.write(to_write)?;
-                        remaining = rest;
+                    if n == 0 {
+                        println!("Stream has no capacity - wait for it to become writable");
+                        let pollable = request_body_stream.subscribe();
+                        pollable.block(); // Wait until stream is ready
+                        continue;
                     }
+
+                    let write_size = std::cmp::min(n, remaining.len() as u64);
+                    let (to_write, rest) = remaining.split_at(write_size as usize);
+                    request_body_stream.write(to_write)?;
+                    remaining = rest;
                 }
 
                 Ok(())

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -172,17 +172,15 @@ impl Client {
     pub fn execute(&self, request: Request) -> Result<Response, crate::Error> {
         let mut header_key_values: Vec<(String, Vec<u8>)> = vec![];
         for (name, value) in self.inner.headers.iter() {
-            match value.to_str() {
-                Ok(value) => header_key_values.push((name.as_str().to_string(), value.into())),
-                Err(_) => {}
+            if let Ok(value) = value.to_str() {
+                header_key_values.push((name.as_str().to_string(), value.into()))
             }
         }
 
         let (method, url, headers, body, timeout, _version) = request.pieces();
         for (name, value) in headers.iter() {
-            match value.to_str() {
-                Ok(value) => header_key_values.push((name.as_str().to_string(), value.into())),
-                Err(_) => {}
+            if let Ok(value) = value.to_str() {
+                header_key_values.push((name.as_str().to_string(), value.into()))
             }
         }
 
@@ -210,24 +208,6 @@ impl Client {
             .set_authority(Some(url.authority()))
             .map_err(|e| failure_point("set_authority", e))?;
 
-        if let Some(mut body) = body {
-            let body_bytes = body.buffer()?;
-            println!("Total body size: {} bytes", body_bytes.len());
-
-            let request_body = request.body().map_err(|e| failure_point("body", e))?;
-            let request_body_stream = request_body
-                .write()
-                .map_err(|e| failure_point("write", e))?;
-
-            // write the whole body in one go
-            if !body_bytes.is_empty() {
-                request_body_stream.write(body_bytes)?;
-            }
-
-            drop(request_body_stream);
-            types::OutgoingBody::finish(request_body, None)?;
-        }
-
         let options = types::RequestOptions::new();
         options
             .set_connect_timeout(self.inner.connect_timeout.map(|d| d.as_nanos() as u64))
@@ -247,7 +227,26 @@ impl Client {
             )
             .map_err(|e| failure_point("set_between_bytes_timeout", e))?;
 
+        let maybe_outgoing_body = if let Some(body) = body {
+            let request_body = request.body().map_err(|e| failure_point("body", e))?;
+            Some((body, request_body))
+        } else {
+            None
+        };
+
         let future_incoming_response = outgoing_handler::handle(request, Some(options))?;
+
+        if let Some((body, outgoing_body)) = maybe_outgoing_body {
+            let request_body_stream = outgoing_body
+                .write()
+                .map_err(|e| failure_point("write", e))?;
+            body.write(|chunk| {
+                request_body_stream.blocking_write_and_flush(chunk)?;
+                Ok(())
+            })?;
+            drop(request_body_stream);
+            types::OutgoingBody::finish(outgoing_body, None)?;
+        }
 
         let receive_timeout = timeout.or(self.inner.first_byte_timeout);
         let incoming_response =

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -216,8 +216,7 @@ impl Client {
                 .write()
                 .map_err(|e| failure_point("write", e))?;
             body.write(|chunk| {
-                request_body_stream.write(chunk)?;
-                request_body_stream.flush()?;
+                request_body_stream.blocking_write_and_flush(chunk)?;
                 Ok(())
             })?;
             drop(request_body_stream);

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -210,20 +210,17 @@ impl Client {
             .set_authority(Some(url.authority()))
             .map_err(|e| failure_point("set_authority", e))?;
 
-        match body {
-            Some(body) => {
-                let request_body = request.body().map_err(|e| failure_point("body", e))?;
-                let request_body_stream = request_body
-                    .write()
-                    .map_err(|e| failure_point("write", e))?;
-                body.write(|chunk| {
-                    request_body_stream.write(chunk)?;
-                    Ok(())
-                })?;
-                drop(request_body_stream);
-                types::OutgoingBody::finish(request_body, None)?;
-            }
-            None => {}
+        if let Some(body) = body {
+            let request_body = request.body().map_err(|e| failure_point("body", e))?;
+            let request_body_stream = request_body
+                .write()
+                .map_err(|e| failure_point("write", e))?;
+            body.write(|chunk| {
+                request_body_stream.write(chunk)?;
+                Ok(())
+            })?;
+            drop(request_body_stream);
+            types::OutgoingBody::finish(request_body, None)?;
         }
 
         let options = types::RequestOptions::new();

--- a/src/wasi/client.rs
+++ b/src/wasi/client.rs
@@ -217,6 +217,7 @@ impl Client {
                 .map_err(|e| failure_point("write", e))?;
             body.write(|chunk| {
                 request_body_stream.write(chunk)?;
+                request_body_stream.flush()?;
                 Ok(())
             })?;
             drop(request_body_stream);


### PR DESCRIPTION
Should fix the following error:
```
[runtime error] failed to invoke function golem:stt-whisper/golem-stt-whisper-api.{test-transcribe-invalid-api-key}: Worker Service - Error: 500 Internal Server Error, Runtime error:
error while executing at wasm backtrace:
    0: 0xf5adc7 - wit-component:shim!indirect-wasi:io/streams@0.2.3-[method]output-stream.write
    1: 0x6b5be - reqwest::bindings::wasi::io::streams::OutputStream::write::h35192dd548aa5ed2
                    at /Users/kmatas/.cargo/git/checkouts/reqwest-ad57e3350eba0a25/6f3f99e/src/bindings.rs:7785:29
    2: 0x3dded - reqwest::wasi::client::Client::execute::{{closure}}::h62bc5eaf67a29ffe
                    at /Users/kmatas/.cargo/git/checkouts/reqwest-ad57e3350eba0a25/6f3f99e/src/wasi/client.rs:220:21
    3: 0x69fb8 - reqwest::wasi::body::Body::write::ha9392e59e7934927
                    at /Users/kmatas/.cargo/git/checkouts/reqwest-ad57e3350eba0a25/6f3f99e/src/wasi/body.rs:175:21
    4: 0x3b5a7 - reqwest::wasi::client::Client::execute::h7920499df21d26f1
                    at /Users/kmatas/.cargo/git/checkouts/reqwest-ad57e3350eba0a25/6f3f99e/src/wasi/client.rs:219:17
    5: 0xa2e88 - reqwest::wasi::request::RequestBuilder::send::h9aaf414616ebd0f4
                    at /Users/kmatas/.cargo/git/checkouts/reqwest-ad57e3350eba0a25/6f3f99e/src/wasi/request.rs:182:9
    6: 0xd409 - golem_stt_whisper::client::TranscriptionsApi::transcribe_audio::h910113b9aafa679d
                    at /Users/kmatas/Repos/Rust/golem/golem-stt/components-rust/golem-stt-whisper/src/client.rs:93:24
    7: 0x5c23 - <golem_stt_whisper::Component as golem_stt_whisper::bindings::exports::golem::stt_whisper::golem_stt_whisper_api::Guest>::test_transcribe_invalid_api_key::h92322d8ac1924aaa
                    at /Users/kmatas/Repos/Rust/golem/golem-stt/components-rust/golem-stt-whisper/src/lib.rs:116:15
    8: 0x986b - golem_stt_whisper::bindings::exports::golem::stt_whisper::golem_stt_whisper_api::_export_test_transcribe_invalid_api_key_cabi::hb6fd61751d0598cf
                    at /Users/kmatas/Repos/Rust/golem/golem-stt/components-rust/golem-stt-whisper/src/bindings.rs:100:35
    9: 0x68ac - golem:stt-whisper/golem-stt-whisper-api#test-transcribe-invalid-api-key
                    at /Users/kmatas/Repos/Rust/golem/golem-stt/components-rust/golem-stt-whisper/src/bindings.rs:237:79: write exceeded budget
```

Issue was that we started to write to the outgoing body steam before the connection was established. Also we should only write max of 4096 bytes based on the minimal documentation I could find.